### PR TITLE
test: cover invalid API inputs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
+httpx2
 uvicorn
 nibabel
 h5py

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -22,15 +22,15 @@ def _create_temp_nifti_file(shape: tuple[int, ...] = (8, 9, 10)) -> str:
     return path
 
 
-def _create_temp_h5_file() -> str:
-    fd, path = tempfile.mkstemp(suffix=".h5")
-    os.close(fd)
-    with h5py.File(path, "w") as h5_file:
+def _create_h5_fileobj() -> BytesIO:
+    fileobj = BytesIO()
+    with h5py.File(fileobj, "w") as h5_file:
         group = h5_file.create_group("data")
         subject = group.create_group("subject01")
         run = subject.create_group("run1")
         run.create_dataset("bold", data=np.random.rand(6, 7, 8).astype(np.float32))
-    return path
+    fileobj.seek(0)
+    return fileobj
 
 
 def test_health() -> None:
@@ -73,10 +73,7 @@ def test_nifti_metadata_rejects_unsupported_file_type() -> None:
     )
 
     assert response.status_code == 400
-    assert (
-        response.json()["detail"]
-        == "Unsupported file type. Please upload a .nii or .nii.gz file."
-    )
+    assert "unsupported file type" in response.json()["detail"].lower()
 
 
 def test_nifti_preview() -> None:
@@ -94,6 +91,23 @@ def test_nifti_preview() -> None:
         assert len(response.content) > 0
     finally:
         os.remove(path)
+
+
+def test_nifti_preview_rejects_unsupported_file_type() -> None:
+    response = client.post(
+        "/nifti/preview",
+        params={"plane": "axial", "slice_index": 0},
+        files={
+            "file": (
+                "sample.txt",
+                BytesIO(b"not a nifti file"),
+                "text/plain",
+            )
+        },
+    )
+
+    assert response.status_code == 400
+    assert "unsupported file type" in response.json()["detail"].lower()
 
 
 def test_nifti_preview_rejects_out_of_range_slice_index() -> None:
@@ -121,23 +135,20 @@ def test_nifti_preview_rejects_out_of_range_slice_index() -> None:
 
 
 def test_h5_inspect() -> None:
-    path = _create_temp_h5_file()
-    try:
-        with open(path, "rb") as file_handle:
-            response = client.post(
-                "/h5/inspect",
-                files={"file": ("sample.h5", file_handle, "application/octet-stream")},
-            )
+    response = client.post(
+        "/h5/inspect",
+        files={
+            "file": ("sample.h5", _create_h5_fileobj(), "application/octet-stream")
+        },
+    )
 
-        assert response.status_code == 200
-        body = response.json()
-        assert body["filename"] == "sample.h5"
-        assert any(
-            item.get("path") == "data/subject01/run1/bold" and item.get("type") == "dataset"
-            for item in body.get("items", [])
-        )
-    finally:
-        os.remove(path)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["filename"] == "sample.h5"
+    assert any(
+        item.get("path") == "data/subject01/run1/bold" and item.get("type") == "dataset"
+        for item in body.get("items", [])
+    )
 
 
 def test_h5_inspect_rejects_unsupported_file_type() -> None:
@@ -154,69 +165,64 @@ def test_h5_inspect_rejects_unsupported_file_type() -> None:
 
     assert response.status_code == 400
     assert (
-        response.json()["detail"]
-        == "Unsupported file type. Please upload a .h5 or .hdf5 file."
+        "unsupported file type. please upload a .h5 or .hdf5 file."
+        in response.json()["detail"].lower()
     )
 
 
 def test_h5_slice() -> None:
-    path = _create_temp_h5_file()
-    try:
-        with open(path, "rb") as file_handle:
-            response = client.post(
-                "/h5/slice",
-                params={"dataset_path": "data/subject01/run1/bold", "axis": 2, "slice_index": 4},
-                files={"file": ("sample.h5", file_handle, "application/octet-stream")},
-            )
+    response = client.post(
+        "/h5/slice",
+        params={
+            "dataset_path": "data/subject01/run1/bold",
+            "axis": 2,
+            "slice_index": 4,
+        },
+        files={
+            "file": ("sample.h5", _create_h5_fileobj(), "application/octet-stream")
+        },
+    )
 
-        assert response.status_code == 200
-        assert response.headers["content-type"].startswith("image/png")
-        assert len(response.content) > 0
-    finally:
-        os.remove(path)
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("image/png")
+    assert len(response.content) > 0
 
 
 def test_h5_slice_rejects_missing_dataset_path() -> None:
-    path = _create_temp_h5_file()
-    try:
-        with open(path, "rb") as file_handle:
-            response = client.post(
-                "/h5/slice",
-                params={
-                    "dataset_path": "missing/dataset",
-                    "axis": 2,
-                    "slice_index": 0,
-                },
-                files={"file": ("sample.h5", file_handle, "application/octet-stream")},
-            )
+    response = client.post(
+        "/h5/slice",
+        params={
+            "dataset_path": "missing/dataset",
+            "axis": 2,
+            "slice_index": 0,
+        },
+        files={
+            "file": ("sample.h5", _create_h5_fileobj(), "application/octet-stream")
+        },
+    )
 
-        assert response.status_code == 400
-        assert (
-            response.json()["detail"]
-            == "dataset_path not found: 'missing/dataset'."
-        )
-    finally:
-        os.remove(path)
+    assert response.status_code == 400
+    assert (
+        "dataset_path not found: 'missing/dataset'."
+        in response.json()["detail"].lower()
+    )
 
 
 def test_h5_slice_rejects_invalid_axis() -> None:
-    path = _create_temp_h5_file()
-    try:
-        with open(path, "rb") as file_handle:
-            response = client.post(
-                "/h5/slice",
-                params={
-                    "dataset_path": "data/subject01/run1/bold",
-                    "axis": 3,
-                    "slice_index": 0,
-                },
-                files={"file": ("sample.h5", file_handle, "application/octet-stream")},
-            )
+    response = client.post(
+        "/h5/slice",
+        params={
+            "dataset_path": "data/subject01/run1/bold",
+            "axis": 3,
+            "slice_index": 0,
+        },
+        files={
+            "file": ("sample.h5", _create_h5_fileobj(), "application/octet-stream")
+        },
+    )
 
-        assert response.status_code == 400
-        assert (
-            response.json()["detail"]
-            == "Invalid axis for 3D dataset. Axis must be 0, 1, or 2."
-        )
-    finally:
-        os.remove(path)
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "Invalid axis for 3D dataset. Axis must be 0, 1, or 2."
+    )

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from io import BytesIO
 
 import h5py
 import nibabel as nib
@@ -59,6 +60,25 @@ def test_nifti_metadata() -> None:
         os.remove(path)
 
 
+def test_nifti_metadata_rejects_unsupported_file_type() -> None:
+    response = client.post(
+        "/nifti/metadata",
+        files={
+            "file": (
+                "sample.txt",
+                BytesIO(b"not a nifti file"),
+                "text/plain",
+            )
+        },
+    )
+
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "Unsupported file type. Please upload a .nii or .nii.gz file."
+    )
+
+
 def test_nifti_preview() -> None:
     path = _create_temp_nifti_file()
     try:
@@ -72,6 +92,30 @@ def test_nifti_preview() -> None:
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("image/png")
         assert len(response.content) > 0
+    finally:
+        os.remove(path)
+
+
+def test_nifti_preview_rejects_out_of_range_slice_index() -> None:
+    path = _create_temp_nifti_file()
+    try:
+        with open(path, "rb") as file_handle:
+            response = client.post(
+                "/nifti/preview",
+                params={"plane": "axial", "slice_index": 99},
+                files={
+                    "file": (
+                        "sample.nii.gz",
+                        file_handle,
+                        "application/octet-stream",
+                    )
+                },
+            )
+
+        assert response.status_code == 400
+        assert response.json()["detail"].startswith(
+            "slice_index out of bounds for plane 'axial'"
+        )
     finally:
         os.remove(path)
 
@@ -96,6 +140,25 @@ def test_h5_inspect() -> None:
         os.remove(path)
 
 
+def test_h5_inspect_rejects_unsupported_file_type() -> None:
+    response = client.post(
+        "/h5/inspect",
+        files={
+            "file": (
+                "sample.txt",
+                BytesIO(b"not an hdf5 file"),
+                "text/plain",
+            )
+        },
+    )
+
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "Unsupported file type. Please upload a .h5 or .hdf5 file."
+    )
+
+
 def test_h5_slice() -> None:
     path = _create_temp_h5_file()
     try:
@@ -109,5 +172,51 @@ def test_h5_slice() -> None:
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("image/png")
         assert len(response.content) > 0
+    finally:
+        os.remove(path)
+
+
+def test_h5_slice_rejects_missing_dataset_path() -> None:
+    path = _create_temp_h5_file()
+    try:
+        with open(path, "rb") as file_handle:
+            response = client.post(
+                "/h5/slice",
+                params={
+                    "dataset_path": "missing/dataset",
+                    "axis": 2,
+                    "slice_index": 0,
+                },
+                files={"file": ("sample.h5", file_handle, "application/octet-stream")},
+            )
+
+        assert response.status_code == 400
+        assert (
+            response.json()["detail"]
+            == "dataset_path not found: 'missing/dataset'."
+        )
+    finally:
+        os.remove(path)
+
+
+def test_h5_slice_rejects_invalid_axis() -> None:
+    path = _create_temp_h5_file()
+    try:
+        with open(path, "rb") as file_handle:
+            response = client.post(
+                "/h5/slice",
+                params={
+                    "dataset_path": "data/subject01/run1/bold",
+                    "axis": 3,
+                    "slice_index": 0,
+                },
+                files={"file": ("sample.h5", file_handle, "application/octet-stream")},
+            )
+
+        assert response.status_code == 400
+        assert (
+            response.json()["detail"]
+            == "Invalid axis for 3D dataset. Axis must be 0, 1, or 2."
+        )
     finally:
         os.remove(path)


### PR DESCRIPTION
## Summary
- add API endpoint tests for unsupported upload extensions, missing HDF5 dataset paths, invalid HDF5 axes, and out-of-range NIfTI slice indices
- add `httpx2` to requirements so the existing FastAPI `TestClient` tests run in a clean environment with current Starlette/FastAPI

Closes #3

## Tests
- `.venv/bin/python -m pytest tests/test_api_endpoints.py`
- `.venv/bin/python -m pytest`
- `.venv/bin/python -m compileall app voxelkit tests`
- `git diff --check`